### PR TITLE
Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,16 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
+  tags:
+    - actions
+    - platform
+  description: Reusable github actions
   name: platform-reusable-github-actions
   annotations:
     github.com/project-slug: empathyco/platform-reusable-github-actions
+    backstage.io/techdocs-ref: dir:.
+    backstage.io/edit-url: https://github.com/empathyco/platform-reusable-github-actions/edit/main/catalog-info.yaml
 spec:
-  type: other
+  type: library
   lifecycle: unknown
   owner: platform-engineering

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: platform-reusable-github-actions
+  annotations:
+    github.com/project-slug: empathyco/platform-reusable-github-actions
+spec:
+  type: other
+  lifecycle: unknown
+  owner: platform-engineering


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [Backstage software catalog](https://backstage.internal.shared.empathy.co).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/software-catalog-overview).